### PR TITLE
Increase memory defaults on ccd-data-store to avoid restarts

### DIFF
--- a/values/ccd-data-store-api.yaml.gotmpl
+++ b/values/ccd-data-store-api.yaml.gotmpl
@@ -58,3 +58,8 @@ app:
         port: 4452
       initialDelaySeconds: 300
       periodSeconds: 30
+    resources:
+      limits:
+        memory: "1024Mi"
+      requests:
+        memory: "256Mi"


### PR DESCRIPTION

### Change description ###

Increase memory defaults on ccd-data-store to avoid restarts

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
