### PR TITLE
add new iac roles

### DIFF
--- a/scripts/create-roles.sh
+++ b/scripts/create-roles.sh
@@ -19,6 +19,9 @@ echo "Setting up Roles..."
 ./actions/create-role.sh "caseworker-ia-iacjudge"
 ./actions/create-role.sh "payments"
 
+./actions/create-role.sh "caseworker-ras-validation"
+./actions/create-role.sh "caseworker-caa"
+
 echo ""
 echo "Setting up Roles required for XUI..."
 ./actions/create-role.sh "pui-case-manager"

--- a/scripts/register-roles.sh
+++ b/scripts/register-roles.sh
@@ -17,6 +17,9 @@ SERVICE_TOKEN="$(sh ./actions/idam-service-token.sh)"
 ./actions/register-role.sh "caseworker-ia-respondentofficer" "$USER_TOKEN" "$SERVICE_TOKEN"
 ./actions/register-role.sh "caseworker-ia-iacjudge" "$USER_TOKEN" "$SERVICE_TOKEN"
 
+./actions/register-role.sh "caseworker-ras-validation" "$USER_TOKEN" "$SERVICE_TOKEN"
+./actions/register-role.sh "caseworker-caa" "$USER_TOKEN" "$SERVICE_TOKEN"
+
 ./actions/register-role.sh "citizen" "$USER_TOKEN" "$SERVICE_TOKEN"
 
 ./actions/register-role.sh "pui-case-manager" "$USER_TOKEN" "$SERVICE_TOKEN"


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RWA-365

As part of the Shar case release done by the IAC team they added some more roles to the CCD def. This change breaks our local env since we don't have those roles. This fix is to add and configure those new roles: 

Steps to fix: 
1. Move onto this ticket branch
2. run the scripts/setup.sh
3. do the yarn upload-wa 

expect: it should import the ccd def successfully now