### PR TITLE
Fix Rolling updates for ingress controller since Minikube v1.24 broke them

### DIFF
--- a/ingress/ingress-patch.yaml
+++ b/ingress/ingress-patch.yaml
@@ -1,4 +1,8 @@
 spec:
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     spec:
       containers:

--- a/scripts/environment/up.sh
+++ b/scripts/environment/up.sh
@@ -33,4 +33,4 @@ kubectl create secret docker-registry $SECRET_NAME \
   -n $NAMESPACE
 
 echo "↪️  Starting deployments"
-#helmfile -n hmcts-local sync
+helmfile -n hmcts-local sync

--- a/scripts/environment/up.sh
+++ b/scripts/environment/up.sh
@@ -33,4 +33,4 @@ kubectl create secret docker-registry $SECRET_NAME \
   -n $NAMESPACE
 
 echo "↪️  Starting deployments"
-helmfile -n hmcts-local sync
+#helmfile -n hmcts-local sync


### PR DESCRIPTION

### JIRA link (if applicable) ###



### Change description ###

Fix Rolling updates for ingress controller since Minikube v1.24 broke them.
Fixed through deployment patch

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
