### PR TITLE
Specify postgres version to use

### DIFF
--- a/helmfile.d/00-ccd-shared-database.yaml
+++ b/helmfile.d/00-ccd-shared-database.yaml
@@ -5,6 +5,7 @@ repositories:
 releases:
   - name: ccd-shared-database
     chart: bitnami/postgresql
+    version: 10.16.2
     values:
       - ./../values/ccd-shared-database.yaml.gotmpl
     wait: true


### PR DESCRIPTION
### Change description ###

Was previously pulling latest postgres chart version - now uses specific version to tie us to Postgres V11.14.0

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
