### PR TITLE
RWA 2262 changed minikube to be version 14

### DIFF
--- a/helmfile.d/00-ccd-shared-database.yaml
+++ b/helmfile.d/00-ccd-shared-database.yaml
@@ -5,7 +5,7 @@ repositories:
 releases:
   - name: ccd-shared-database
     chart: bitnami/postgresql
-    version: 11.6.10
+    version: 11.9.13
     values:
       - ./../values/ccd-shared-database.yaml.gotmpl
     wait: true

--- a/values/ccd-shared-database.yaml.gotmpl
+++ b/values/ccd-shared-database.yaml.gotmpl
@@ -1,7 +1,7 @@
 image:
   debug: true
   repository: bitnami/postgresql
-  tag: 11.16.0
+  tag: 14.5.0
   pullPolicy: IfNotPresent
 
 fullnameOverride: ccd-shared-database


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RWA-2262


### Change description ###
Upped postgres to version 14.5


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
